### PR TITLE
Update the doc and import link from CDN

### DIFF
--- a/readme.fr.md
+++ b/readme.fr.md
@@ -15,7 +15,7 @@ Pour utiliser le module, suivez les étapes ci-dessous pour charger les assets d
 
 ```html
     <!-- Utilisez ceci pour le css -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/DoniLite/CSS/md.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/DoniLite/TrickCSS/md.css">
 
     <!-- Ajoutez le thème de highlight pour bénéficier de la coloration syntaxique -->
     <!-- si vous souhaitez obtenir plus de thème référer vous à la documentation officieelle du site https://highlightjs.org/#usage -->
@@ -24,17 +24,17 @@ Pour utiliser le module, suivez les étapes ci-dessous pour charger les assets d
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
 
     <!-- Pour le javaScript -->
-     <script type="module" src="https://cdn.jsdelivr.net/gh/DoniLite/CSS/md.js" defer></script>
+     <script type="module" src="https://cdn.jsdelivr.net/gh/DoniLite/TrickCSS/md.js" defer></script>
 ```
 
 Si vous souhaitez charger le dernier module ou une version spécifique, considérez cette syntaxe:
 
 ```html
     <!-- Pour la derniere version actuellement disponible -->
-     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/DoniLite/CSS@latest/md.css">
+     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/DoniLite/TrickCSS@latest/md.css">
 
      <!-- Si vous souhaitez charger une version specifique -->
-      <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/DoniLite/CSS@{{numero_spécifique_de_version}}/md.css">
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/DoniLite/TrickCSS@{{numero_spécifique_de_version}}/md.css">
 ```
 
 ## Application du style

--- a/readme.fr.md
+++ b/readme.fr.md
@@ -18,7 +18,7 @@ Pour utiliser le module, suivez les étapes ci-dessous pour charger les assets d
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/DoniLite/TrickCSS/md.css">
 
     <!-- Ajoutez le thème de highlight pour bénéficier de la coloration syntaxique -->
-    <!-- si vous souhaitez obtenir plus de thème référer vous à la documentation officieelle du site https://highlightjs.org/#usage -->
+    <!-- si vous souhaitez obtenir plus de thème référer vous à la documentation officielle du site https://highlightjs.org/#usage -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github-dark.min.css"/>
     <!-- Insérez le script -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ To use the module, follow these steps to load assets from CDN servers:
 
 ```html
     <!-- Use this for CSS -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/DoniLite/CSS/md.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/DoniLite/TrickCSS/md.css">
 
     <!-- Add highlight theme for syntax coloring -->
     <!-- For more themes, refer to the official documentation https://highlightjs.org/#usage -->
@@ -27,17 +27,17 @@ To use the module, follow these steps to load assets from CDN servers:
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
 
     <!-- For JavaScript -->
-     <script type="module" src="https://cdn.jsdelivr.net/gh/DoniLite/CSS/md.js" defer></script>
+     <script type="module" src="https://cdn.jsdelivr.net/gh/DoniLite/TrickCSS/md.js" defer></script>
 ```
 
 If you want to load the latest module or a specific version, consider this syntax:
 
 ```html
     <!-- For the latest currently available version -->
-     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/DoniLite/CSS@latest/md.css">
+     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/DoniLite/TrickCSS@latest/md.css">
 
      <!-- If you want to load a specific version -->
-      <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/DoniLite/CSS@{{specific_version_number}}/md.css">
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/DoniLite/TrickCSS@{{specific_version_number}}/md.css">
 ```
 
 ## Style Application


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update documentation to use the correct CDN link for TrickCSS.